### PR TITLE
fix(KFLUXBUGS-1182): update infra deployment use target git repo from data

### DIFF
--- a/tasks/update-infra-deployments/README.md
+++ b/tasks/update-infra-deployments/README.md
@@ -12,12 +12,16 @@
 | snapshotPath            | Path to snapshot json file                                                                   | false    |                                                                                                                                                  |
 | originRepo              | URL of github repository which was built by the Pipeline                                     | false    |                                                                                                                                                  |
 | revision                | Git reference which was built by the Pipeline                                                | false    |                                                                                                                                                  |
-| targetGHRepo            | GitHub repository of the infra-deployments code                                              | true     | redhat-appstudio/infra-deployments                                                                                                               |
 | gitImage                | Image reference containing the git command                                                   | true     | registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8 |
 | scriptImage             | Image reference for SCRIPT execution                                                         | true     | quay.io/mkovarik/ose-cli-git:4.11                                                                                                                |
 | sharedSecret            | Secret in the namespace which contains private key for the GitHub App                        | true     | infra-deployments-pr-creator                                                                                                                     |
 | githubAppID             | ID of Github app used for updating PR                                                        | true     | 305606                                                                                                                                           |
 | githubAppInstallationID | Installation ID of Github app in the organization                                            | true     | 35269675                                                                                                                                         |
+
+## Changes in 0.5.1
+- Modified `update-infra-deployments` task to dynamically fetch `targetGHRepo` from the `dataJsonPath` JSON file using `jsonPath`.
+- Removed default value for `targetGHRepo` parameter to ensure the repository is specified in the data file.
+- Updated task description to reflect the dynamic repository selection.
 
 ## Changes since 0.4.1
 - Updated hacbs-release/release-utils image to reference redhat-appstudio/release-service-utils image instead

--- a/tasks/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/update-infra-deployments/update-infra-deployments.yaml
@@ -3,24 +3,21 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/version: "0.5.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "release"
   name: update-infra-deployments
 spec:
   description: |
-   This task clones redhat-appstudio/infra-deployments GH repository.
-   It then runs a script obtained from the infra-deployment-update-script key in data which can modify text files
-   It then generates pull-request for redhat-appstudio/infra-deployments repository using the modified files.
+    This task clones a specified GitHub repository.
+    It then runs a script obtained from the infra-deployment-update-script key in the data file, which can modify text files.
+    It then generates a pull request for the specified repository using the modified files.
   params:
     - name: dataJsonPath
       description: path to data json file
     - name: snapshotPath
       description: path to snapshot json file
-    - name: targetGHRepo
-      description: GitHub repository of the infra-deployments code
-      default: redhat-appstudio/infra-deployments
     - name: gitImage
       description: Image reference containing the git command
       default: >-
@@ -54,8 +51,11 @@ spec:
       workingDir: /shared
       env:
         - name: TARGET_GH_REPO
-          value: "$(params.targetGHRepo)"
+          valueFrom:
+            jsonPath: "$(params.dataJsonPath)"  # Path to the data json file
+            path: ".targetGHRepo"  # Key in the json to retrieve the value
       script: |
+        echo "Cloning $TARGET_GH_REPO"
         git clone "https://github.com/${TARGET_GH_REPO}.git" cloned
     - name: run-update-script
       image: $(params.scriptImage)
@@ -70,8 +70,7 @@ spec:
         cat "$(params.snapshotPath)"
         echo ""
         
-        # we assume we only have one component in the service.
-        #
+        # We assume we only have one component in the service.
         revision=$(cat "$(params.snapshotPath)" | jq -r .components[0].source.git.revision)
         echo "revision: $revision"
         echo $revision > ../revision.txt
@@ -80,7 +79,13 @@ spec:
         echo "origin repo: $originRepo"
         echo $originRepo > ../originRepo.txt
 
-        # get SCRIPT from Data
+        TARGET_GH_REPO=$(cat "$(params.dataJsonPath)" | jq -r '.targetGHRepo')
+        if [ -z "$TARGET_GH_REPO" ]; then
+          echo "Error: 'targetGHRepo' key missing in data file!"
+          exit 1
+        fi
+
+        # Get SCRIPT from Data
         echo "data: $(params.dataJsonPath)"
         SCRIPT=$(cat "$(params.dataJsonPath)" | jq -r '."infra-deployment-update-script" // empty')
 
@@ -124,7 +129,9 @@ spec:
         - name: GITHUB_API_URL
           value: https://api.github.com
         - name: TARGET_GH_REPO
-          value: "$(params.targetGHRepo)"
+          valueFrom:
+            jsonPath: "$(params.dataJsonPath)"  # Path to the data json file
+            path: ".targetGHRepo"  # Key in the json to retrieve the value
       script: |
         #!/usr/bin/env python3
         import json


### PR DESCRIPTION
… from data

- Modified `update-infra-deployments` task to dynamically fetch `targetGHRepo` from the `dataJsonPath` JSON file using `jsonPath`.
- Removed default value for `targetGHRepo` parameter to ensure the repository is specified in the data file.
- Updated task description to reflect the dynamic repository selection.