### PR TITLE
fix(KONFLUX-7002): remove platform parameter for source container

### DIFF
--- a/tasks/managed/push-snapshot/README.md
+++ b/tasks/managed/push-snapshot/README.md
@@ -13,6 +13,9 @@ Tekton task to push snapshot images to an image registry using `cosign copy`.
 | caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from                     | Yes      | trusted-ca    |
 | caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data     | Yes      | ca-bundle.crt |
 
+## Changes in 6.4.3
+* Fix source container image handling by removing platform-specific parameters
+
 ## Changes in 6.4.2
 * Fix checkton/shellcheck linting issues
 

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "6.4.2"
+    app.kubernetes.io/version: "6.4.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -168,7 +168,7 @@ spec:
             sourceContainer="${source_repo}:${source_tag}"
             # Check if the source container exists
             source_container_digest=$(oras resolve --registry-config "$SOURCE_AUTH_FILE" \
-              "${sourceContainer}" "${oras_args[@]}")
+              "${sourceContainer}")
 
             if [ -z "$source_container_digest" ] ; then
               echo "Error: Source container ${sourceContainer} not found!"
@@ -177,7 +177,7 @@ spec:
             # Push the source image with the source tag here. The source image will be
             # pushed with the provided tags below in the loop
             push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
-              "${repository}" "${source_tag}" "$platform"
+              "${repository}" "${source_tag}" ""
           fi
 
           for tag in $(jq -r '.[]' <<< "$imageTags") ; do
@@ -189,7 +189,7 @@ spec:
             # be pushed for this component
             if [ -n "${source_container_digest-}" ] ; then
               push_image "${source_container_digest}" "${name}" "${sourceContainer}" \
-                "${repository}" "${tag}-source" "$platform"
+                "${repository}" "${tag}-source" ""
             fi
           done
         done

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-pushsourcecontainer-multiarch.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-pushsourcecontainer-multiarch
+spec:
+  description: |
+    Test push-snapshot with a multi-architecture main image and source container to ensure .src
+     resolves and pushes without platform args.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir "$(workspaces.data.path)/results"
+              cat > "$(workspaces.data.path)"/snapshot.json << EOF
+              {
+                "application": "multiarch-app",
+                "components": [
+                  {
+                    "name": "multi-comp",
+                    "containerImage": "reg.io/test@sha256:abcdefg",
+                    "repository": "prod.io/loc",
+                    "tags": ["multi-tag"],
+                    "pushSourceContainer": true
+                  }
+                ]
+              }
+              EOF
+              cat > "$(workspaces.data.path)"/data.json << EOF
+              {
+                "mapping": {}
+              }
+              EOF
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: snapshot.json
+        - name: dataPath
+          value: data.json
+        - name: retries
+          value: "0"
+        - name: resultsDirPath
+          value: results
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      runAfter:
+        - setup
+    - name: check-result
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      taskSpec:
+        workspaces:
+          - name: data
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils:76021ef1e9f0f14397260ee24c9a43e37d3f83ac
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              cat > "$(workspaces.data.path)"/cosign_expected_calls.txt << EOF
+              copy -f reg.io/test@sha256:abcdefg prod.io/loc:multi-tag
+              EOF
+
+              if [ "$(md5sum < "$(workspaces.data.path)"/cosign_expected_calls.txt)" \
+                != "$(md5sum < "$(workspaces.data.path)/mock_cosign.txt")" ]; then
+                echo "Error: Expected cosign calls do not match actual calls"
+                cat "$(workspaces.data.path)/mock_cosign.txt"
+                echo "Expected:"
+                cat "$(workspaces.data.path)"/cosign_expected_calls.txt
+                exit 1
+              fi
+
+              grep "resolve --registry-config .* reg.io/test:sha256-abcdefg.src$" \
+                "$(workspaces.data.path)/mock_oras.txt" || {
+                echo "Error: Source .src resolution call missing or incorrect"
+                exit 1
+              }
+              if grep "resolve --registry-config .* --platform .* reg.io/test:sha256-abcdefg.src" \
+                "$(workspaces.data.path)/mock_oras.txt"; then
+                echo "Error: Source .src resolution should not use --platform"
+                exit 1
+              fi
+
+              grep "resolve --registry-config .* prod.io/loc:sha256-abcdefg.src$" \
+                "$(workspaces.data.path)/mock_oras.txt" || {
+                echo "Error: Initial .src push call missing or incorrect"
+                exit 1
+              }
+              if grep "resolve --registry-config .* --platform .* prod.io/loc:sha256-abcdefg.src" \
+                "$(workspaces.data.path)/mock_oras.txt"; then
+                echo "Error: Initial .src push should not use --platform"
+                exit 1
+              fi
+
+              grep "resolve --registry-config .* prod.io/loc:multi-tag-source$" \
+                "$(workspaces.data.path)/mock_oras.txt" || {
+                echo "Error: Tagged .src push call missing or incorrect"
+                exit 1
+              }
+              if grep "resolve --registry-config .* --platform .* prod.io/loc:multi-tag-source" \
+                "$(workspaces.data.path)/mock_oras.txt"; then
+                echo "Error: Tagged .src push should not use --platform"
+                exit 1
+              fi
+      runAfter:
+        - run-task


### PR DESCRIPTION
This commit removes the `platform` specification when pushing source containers.

Key points:
- Source containers are not multiarch and thus do not require different platform tags.
- The build process  handles main images as multiarch, but source containers are uniformly single-architecture across all builds.