### PR TITLE
feat(RELEASE-1263): add idempotency to rh advisories pipeline

### DIFF
--- a/tasks/internal/filter-already-released-advisory-images-task/README.md
+++ b/tasks/internal/filter-already-released-advisory-images-task/README.md
@@ -1,0 +1,24 @@
+# filter-already-released-advisory-images-task
+
+This internal Tekton task filters out images from a snapshot if they have already
+been published in an advisory stored in a GitLab repository. It supports idempotency
+for the `rh-advisories` pipeline by ensuring that previously released images are not
+included in subsequent release operations.
+
+## Parameters
+
+| Name                        | Description                                                                 |
+|-----------------------------|-----------------------------------------------------------------------------|
+| `snapshot_json`             | String containing the full JSON representation of the snapshot spec        |
+| `origin`                    | The origin workspace for the release CR (used to locate advisories)        |
+| `advisory_secret_name`      | Name of the secret containing GitLab repo and token information             |
+| `internalRequestPipelineRunName` | UID of the PipelineRun that invoked the InternalRequest                    |
+
+## Results
+
+| Name                          | Description                                                         |
+|-------------------------------|---------------------------------------------------------------------|
+| `result`                      | `Success` or a detailed error message                               |
+| `filtered_snapshot`           | Snapshot JSON string containing only images not already released    |
+| `internalRequestPipelineRunName` | The PipelineRun UID that triggered this task                        |
+| `internalRequestTaskRunName`  | The TaskRun name of this internal task instance                     |

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: filter-already-released-advisory-images-task
+  labels:
+    app.kubernetes.io/version: "1.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |
+    Filters out images from a snapshot if they are already published in an advisory
+    stored in the GitLab advisory repo. Result is a cleaned snapshot JSON string.
+  params:
+    - name: snapshot_json
+      type: string
+      description: String containing a JSON representation of the snapshot spec
+    - name: origin
+      description: The origin workspace for the release CR
+      type: string
+    - name: advisory_secret_name
+      description: Name of the secret containing advisory metadata
+      type: string
+    - name: internalRequestPipelineRunName
+      description: Name of the PipelineRun that requested this task
+      type: string
+  workspaces:
+    - name: data
+      description: Workspace containing the snapshot and advisory data
+  results:
+    - name: result
+      description: Success or error message
+    - name: filtered_snapshot
+      description: The filtered snapshot JSON (with unpublished images only)
+    - name: internalRequestPipelineRunName
+      description: Name of the PipelineRun that requested this task
+    - name: internalRequestTaskRunName
+      description: Name of this Task Run to be made available to caller
+  steps:
+    - name: filter-images
+      image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+      env:
+        - name: GITLAB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: gitlab_host
+        - name: ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: gitlab_access_token
+        - name: GIT_REPO
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: git_repo
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+
+        STDERR_FILE=/tmp/stderr.txt
+        echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
+        echo -n "$(context.taskRun.name)" > "$(results.internalRequestTaskRunName.path)"
+
+        exitfunc() {
+            local err=$1
+            local line=$2
+            local command="$3"
+            if [ "$err" -eq 0 ] ; then
+                echo -n "Success" > "$(results.result.path)"
+            else
+                echo -n \
+                  "$0: ERROR '$command' failed at line $line - exited with status $err" > "$(results.result.path)"
+                if [ -f "$STDERR_FILE" ] ; then
+                    tail -n 20 "$STDERR_FILE" >> "$(results.result.path)"
+                fi
+            fi
+            exit 0
+        }
+        trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+        SNAPSHOT_JSON="$(params.snapshot_json)"
+        ORIGIN="$(params.origin)"
+        ADVISORY_BASE_DIR="data/advisories/${ORIGIN}"
+
+        echo "Cloning advisory repo..."
+        cd /tmp
+
+        # shellcheck source=/dev/null
+        . /home/utils/gitlab-functions
+        # shellcheck source=/dev/null
+        . /home/utils/git-functions
+        gitlab_init
+        git_functions_init
+
+        git_clone_and_checkout --repository "$GIT_REPO" --revision main
+
+        echo "Checking existing advisories in ${ADVISORY_BASE_DIR}..."
+        EXISTING_ADVISORIES=$(find "${ADVISORY_BASE_DIR}" -mindepth 2 -type d -printf "%T@ %p\n" |
+          sort -nr | cut -d' ' -f2- | sed "s|^${ADVISORY_BASE_DIR}/||")
+
+        if [[ -z "$EXISTING_ADVISORIES" ]]; then
+          echo "No existing advisories found. Returning original snapshot."
+          echo -n "$SNAPSHOT_JSON" > "$(results.filtered_snapshot.path)"
+          echo -n "Success" > "$(results.result.path)"
+          exit 0
+        fi
+
+        CONTENT_IMAGES=$(echo "$SNAPSHOT_JSON" | jq -c '.components')
+
+        for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
+          ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
+          EXISTING_CONTENT=$(yq -o=json '.spec.content.images // []' "$ADVISORY_FILE")
+
+          echo "Comparing against: $ADVISORY_FILE"
+
+          CONTENT_IMAGES=$(echo "$CONTENT_IMAGES" | jq --argjson existing "$EXISTING_CONTENT" '
+            map(select(
+              .containerImage as $ci |
+              .tags as $tags |
+              .repository as $repo |
+              ($existing | map(select(
+                .containerImage == $ci and .tags == $tags and .repository == $repo
+              )) | length == 0)
+            ))')
+        done
+
+        ORIGINAL_COUNT=$(echo "$SNAPSHOT_JSON" | jq '.components | length')
+        NEW_COUNT=$(echo "$CONTENT_IMAGES" | jq 'length')
+        echo "Filtered out $((ORIGINAL_COUNT - NEW_COUNT)) image(s) already in advisories"
+        echo "Remaining unpublished images: $CONTENT_IMAGES"
+
+        FILTERED_SNAPSHOT=$(echo "$SNAPSHOT_JSON" | jq --argjson images "$CONTENT_IMAGES" '.components = $images')
+
+        echo -n "$FILTERED_SNAPSHOT" > "$(results.filtered_snapshot.path)"
+        echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/mocks.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Mock gitlab-functions ---
+gitlab_init() {
+  echo "Mock gitlab_init called"
+}
+
+# --- Mock git-functions ---
+git_functions_init() {
+  echo "Mock git_functions_init called"
+}
+
+# --- Mock git_clone_and_checkout ---
+git_clone_and_checkout() {
+  echo "Mock git_clone_and_checkout called"
+
+  mkdir -p /tmp/data/advisories/stage/20240426-123456/
+  cat <<EOF > /tmp/data/advisories/stage/20240426-123456/advisory.yaml
+spec:
+  content:
+    images:
+      - containerImage: quay.io/example/image1@sha256:aaa
+        tags: ["latest"]
+        repository: quay.io/example
+EOF
+}
+
+# --- Mock find command ---
+find() {
+  echo "Mock find called with: $*" >&2
+  if echo "$*" | grep -q "/data/advisories/stage"; then
+    echo "1712012345.0 /tmp/data/advisories/stage/20240426-123456"
+  else
+    echo "Error: Unexpected find command: $*" >&2
+    exit 1
+  fi
+}
+
+# --- Mock yq command ---
+yq() {
+  echo "Mock yq called with: $*" >&2
+  if [[ "$2" == ".spec.content.images // []" ]]; then
+    # Return the advisory image we injected
+    echo '[{"containerImage":"quay.io/example/image1@sha256:aaa","tags":["latest"],"repository":"quay.io/example"}]'
+  else
+    echo "Error: Unexpected yq query: $2" >&2
+    exit 1
+  fi
+}

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# $1 is the path to the Task YAML
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks.sh content at the beginning of the task's first step script
+yq -i '.spec.steps[0].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+# No need to create any Kubernetes secrets for this task
+echo "Injected mocks.sh into the Task script successfully"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-images-task
+spec:
+  params: []
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-filter-task
+      taskRef:
+        name: filter-already-released-advisory-images-task
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: snapshot_json
+          value: |
+            {
+              "application": "myapp",
+              "components": [
+                {
+                  "name": "comp1",
+                  "repository": "quay.io/redhat-prod/repo",
+                  "containerImage": "quay.io/redhat-prod/repo@sha256:123",
+                  "tags": ["v1.0", "latest"]
+                },
+                {
+                  "name": "comp2",
+                  "repository": "quay.io/redhat-prod/repo",
+                  "containerImage": "quay.io/redhat-prod/repo@sha256:456",
+                  "tags": ["v2.0"]
+                }
+              ]
+            }
+        - name: origin
+          value: "dev-tenant"
+        - name: advisory_secret_name
+          value: "dummy-secret"
+        - name: internalRequestPipelineRunName
+          value: "$(context.pipelineRun.uid)"
+
+    - name: validate-filtered-result
+      runAfter:
+        - run-filter-task
+      taskSpec:
+        params:
+          - name: filtered_snapshot
+            type: string
+          - name: result
+            type: string
+        steps:
+          - name: check-filtering
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo "Task did not succeed: $(params.result)"
+                exit 1
+              fi
+
+              echo "Filtered Snapshot Content:"
+              echo '$(params.filtered_snapshot)' | jq .
+
+              # Expect only 1 component left after filtering
+              component_count=$(echo '$(params.filtered_snapshot)' | jq '.components | length')
+
+              if [[ "$component_count" -ne 1 ]]; then
+                echo "Expected 1 component remaining after filtering, found $component_count"
+                exit 1
+              fi
+      params:
+        - name: filtered_snapshot
+          value: "$(tasks.run-filter-task.results.filtered_snapshot)"
+        - name: result
+          value: "$(tasks.run-filter-task.results.result)"


### PR DESCRIPTION
Add filter-already-released-advisory-images task to make rh-advisories pipeline idempotent

- Creates new task to filter out images already published in advisories
- Places task after apply-mapping and before EC validation
- Updates all subsequent tasks to use filtered snapshot
- Includes tests and documentation