### PR TITLE
feat(RELEASE-1263): add idempotency to rh advisories pipeline

### DIFF
--- a/pipelines/internal/filter-already-released-advisory-images/README.md
+++ b/pipelines/internal/filter-already-released-advisory-images/README.md
@@ -1,0 +1,13 @@
+# filter-already-released-advisory-images pipeline
+
+This pipeline filters out images from a snapshot that have already been published in advisories.  
+
+## Parameters
+
+| Name                 | Description                                                                                            | Optional | Default value                                             |
+|----------------------|--------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| snapshot_json        | JSON string of the Snapshot spec containing the images to be filtered                                  | No       | -                                                         |
+| origin               | The origin workspace where the release CR comes from. This is used to determine the advisory path      | No       | -                                                         |
+| advisory_secret_name | The name of the secret that contains the advisory creation metadata                                    | No       | -                                                         |
+| taskGitUrl           | The url to the git repo where the release-service-catalog tasks to be used are stored                  | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision      | The revision in the taskGitUrl repo to be used                                                         | No       | -                                                         |

--- a/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: filter-already-released-advisory-images
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Pipeline to filter out already-released images from a snapshot
+  params:
+    - name: snapshot_json
+      type: string
+      description: JSON string of the Snapshot spec
+    - name: origin
+      type: string
+      description: |
+          The origin workspace where the release CR comes from.
+          This is used to determine the advisory path
+    - name: advisory_secret_name
+      type: string
+      description: The name of the secret that contains the advisory creation metadata
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+  tasks:
+    - name: filter-already-released-advisory-images-task
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+      params:
+        - name: snapshot_json
+          value: $(params.snapshot_json)
+        - name: origin
+          value: $(params.origin)
+        - name: advisory_secret_name
+          value: $(params.advisory_secret_name)
+        - name: internalRequestPipelineRunName
+          value: $(context.pipelineRun.name)
+  results:
+    - name: result
+      value: $(tasks.filter-already-released-advisory-images-task.results.result)
+    - name: filtered_snapshot
+      value: $(tasks.filter-already-released-advisory-images-task.results.filtered_snapshot)
+    - name: internalRequestPipelineRunName
+      value: $(tasks.filter-already-released-advisory-images-task.results.internalRequestPipelineRunName)
+    - name: internalRequestTaskRunName
+      value: $(tasks.filter-already-released-advisory-images-task.results.internalRequestTaskRunName)

--- a/pipelines/managed/rh-advisories/README.md
+++ b/pipelines/managed/rh-advisories/README.md
@@ -28,6 +28,12 @@ the rh-push-to-registry-redhat-io pipeline.
 | trustedArtifactsDebug           | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                             | Yes      | ""                                                        |
 | dataDir                         | The location where data will be stored                                                                                             | Yes      | /var/workdir/release                                      |
 
+## Changes in 2.1.0
+* Add new task `filter-already-released-advisory-images` to filter out images that have already been released in advisories
+  * Task is placed after `apply-mapping` and before `verify-conforma`
+  * Updates subsequent tasks to use the filtered snapshot
+  * Makes the pipeline idempotent by preventing validation failures for already released images
+
 ## Changes in 2.0.2
 * Temporarily allow the `close-advisory-issues` task to fail
   * Until https://issues.redhat.com/browse/KONFLUX-7489 is fixed

--- a/pipelines/managed/rh-advisories/rh-advisories.yaml
+++ b/pipelines/managed/rh-advisories/rh-advisories.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: rh-advisories
   labels:
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -247,6 +247,46 @@ spec:
           workspace: release-workspace
       runAfter:
         - reduce-snapshot
+    - name: filter-already-released-advisory-images
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+      params:
+        - name: snapshotPath
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: releasePlanAdmissionPath
+          value: "$(tasks.collect-data.results.releasePlanAdmission)"
+        - name: resultsDirPath
+          value: "$(tasks.collect-data.results.resultsDir)"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: dataPath
+          value: "$(tasks.collect-data.results.data)"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: "$(tasks.apply-mapping.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: "$(params.trustedArtifactsDebug)"
+        - name: taskGitUrl
+          value: "$(params.taskGitUrl)"
+        - name: taskGitRevision
+          value: "$(params.taskGitRevision)"
+        - name: subdirectory
+          value: "$(tasks.collect-data.results.subdirectory)"
+      workspaces:
+        - name: data
+          workspace: release-workspace
+      runAfter:
+        - apply-mapping
     - name: verify-conforma
       timeout: "4h00m0s"
       taskRef:
@@ -260,7 +300,7 @@ spec:
             value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
       params:
         - name: SNAPSHOT_FILENAME
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
@@ -281,14 +321,14 @@ spec:
         - name: TRUSTED_ARTIFACTS_DEBUG
           value: "$(params.trustedArtifactsDebug)"
       runAfter:
-        - apply-mapping
+        - filter-already-released-advisory-images
     - name: populate-release-notes
       timeout: "4h"  # temp workaround until github.com/konflux-ci/release-service/issues/603 is fixed
       params:
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
         - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: ociStorage
           value: $(params.ociStorage)
         - name: sourceDataArtifact
@@ -311,7 +351,7 @@ spec:
             value: tasks/managed/populate-release-notes/populate-release-notes.yaml
         resolver: git
       runAfter:
-        - apply-mapping
+        - filter-already-released-advisory-images
       workspaces:
         - name: data
           workspace: release-workspace
@@ -428,7 +468,7 @@ spec:
             value: tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
       params:
         - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: secretName
           value: "$(tasks.collect-cosign-params.results.cosign-secret-name)"
         - name: signRegistryAccessPath
@@ -469,7 +509,7 @@ spec:
             value: tasks/managed/push-snapshot/push-snapshot.yaml
       params:
         - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
         - name: resultsDirPath
@@ -535,7 +575,7 @@ spec:
             value: tasks/managed/rh-sign-image/rh-sign-image.yaml
       params:
         - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
         - name: releasePlanAdmissionPath
@@ -594,7 +634,7 @@ spec:
         - name: rhPush
           value: "true"
         - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
         - name: ociStorage
@@ -632,7 +672,7 @@ spec:
         - name: pyxisSecret
           value: $(tasks.collect-pyxis-params.results.secret)
         - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
         - name: resultsDirPath
@@ -790,7 +830,7 @@ spec:
         - name: jsonKey
           value: ".fileUpdates"
         - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
         - name: resultsDirPath
@@ -983,7 +1023,7 @@ spec:
         - name: releasePlanAdmissionPath
           value: "$(tasks.collect-data.results.releasePlanAdmission)"
         - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
+          value: "$(tasks.filter-already-released-advisory-images.results.filtered_snapshot)"
         - name: dataPath
           value: "$(tasks.collect-data.results.data)"
         - name: resultsDirPath

--- a/tasks/internal/filter-already-released-advisory-images-task/README.md
+++ b/tasks/internal/filter-already-released-advisory-images-task/README.md
@@ -1,0 +1,13 @@
+# filter-already-released-advisory-images-task
+
+This internal Tekton task filters out images from a snapshot if they have already
+been published in an advisory stored in a GitLab repository.
+
+## Parameters
+
+| Name                           | Description                                                                                            | Optional | Default value |
+|--------------------------------|--------------------------------------------------------------------------------------------------------|----------|---------------|
+| snapshot_json                  | String containing the full JSON representation of the snapshot spec                                    | No       | -             |
+| origin                         | The origin workspace for the release CR (used to locate advisories)                                    | No       | -             |
+| advisory_secret_name           | Name of the secret containing GitLab repo and token information                                        | No       | -             |
+| internalRequestPipelineRunName | Name of the PipelineRun that called this task                                                          | No       | -             |

--- a/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/filter-already-released-advisory-images-task.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: filter-already-released-advisory-images-task
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |
+    Filters out images from a snapshot if they are already published in an advisory
+    stored in the GitLab advisory repo. Result is a cleaned snapshot JSON string.
+  params:
+    - name: snapshot_json
+      type: string
+      description: String containing a JSON representation of the snapshot spec
+    - name: origin
+      description: The origin workspace for the release CR
+      type: string
+    - name: advisory_secret_name
+      description: Name of the secret containing advisory metadata
+      type: string
+    - name: internalRequestPipelineRunName
+      description: Name of the PipelineRun that requested this task
+      type: string
+  results:
+    - name: result
+      description: Success or error message
+    - name: filtered_snapshot
+      description: The filtered snapshot JSON (with unpublished images only)
+    - name: internalRequestPipelineRunName
+      description: Name of the PipelineRun that requested this task
+    - name: internalRequestTaskRunName
+      description: Name of this Task Run to be made available to caller
+  steps:
+    - name: filter-images
+      image: quay.io/konflux-ci/release-service-utils:0b2f257d7a5c2a881c36c23f8ae3cd5e89db593a
+      env:
+        - name: GITLAB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: gitlab_host
+        - name: ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: gitlab_access_token
+        - name: GIT_REPO
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: git_repo
+        - name: GIT_AUTHOR_NAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: git_author_name
+        - name: GIT_AUTHOR_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.advisory_secret_name)
+              key: git_author_email
+        - name: SNAPSHOT_JSON
+          value: "$(params.snapshot_json)"
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+
+        STDERR_FILE=/tmp/stderr.txt
+        echo -n "$(params.internalRequestPipelineRunName)" > "$(results.internalRequestPipelineRunName.path)"
+        echo -n "$(context.taskRun.name)" > "$(results.internalRequestTaskRunName.path)"
+
+        exitfunc() {
+          local err=$1
+          local line=$2
+          local cmd=$3
+          if [ "$err" -eq 0 ]; then
+            echo -n "Success" > "$(results.result.path)"
+          else
+            echo -n "$0: ERROR '$cmd' failed at line $line - exited with status $err" > "$(results.result.path)"
+            if [ -f "$STDERR_FILE" ]; then tail -n 20 "$STDERR_FILE" >> "$(results.result.path)"; fi
+          fi
+          exit 0
+        }
+        trap 'exitfunc $? $LINENO "$BASH_COMMAND"' EXIT
+
+        ORIGIN="$(params.origin)"
+        ADVISORY_BASE_DIR="data/advisories/${ORIGIN}"
+
+        cd /tmp
+
+        echo "Cloning $GIT_REPO..."
+        git clone "$GIT_REPO" repo
+        cd repo
+
+        echo "Checking existing advisories in ${ADVISORY_BASE_DIR}..."
+        EXISTING_ADVISORIES=""
+        if [ -d "${ADVISORY_BASE_DIR}" ]; then
+          EXISTING_ADVISORIES=$(
+            find "${ADVISORY_BASE_DIR}" -mindepth 2 -type d -printf "%T@ %p\n" |
+            sort -nr | cut -d' ' -f2- | sed "s|^${ADVISORY_BASE_DIR}/||"
+          )
+        fi
+
+        if [[ -z "$EXISTING_ADVISORIES" ]]; then
+          echo "No existing advisories found. Returning original snapshot."
+          echo -n "$SNAPSHOT_JSON" > "$(results.filtered_snapshot.path)"
+          echo -n "Success" > "$(results.result.path)"
+          exit 0
+        fi
+
+        CONTENT_IMAGES=$(jq -c '.components' <<< "$SNAPSHOT_JSON")
+
+        for ADVISORY_SUBDIR in $EXISTING_ADVISORIES; do
+          ADVISORY_FILE="${ADVISORY_BASE_DIR}/${ADVISORY_SUBDIR}/advisory.yaml"
+          EXISTING_CONTENT=$(yq -o=json '.spec.content.images // []' "$ADVISORY_FILE")
+
+          echo "Comparing against: $ADVISORY_FILE"
+
+          CONTENT_IMAGES=$(echo "$CONTENT_IMAGES" | jq --argjson existing "$EXISTING_CONTENT" '
+            map(select(
+              .containerImage as $ci |
+              .tags as $tags |
+              .repository as $repo |
+              ($existing | map(select(
+                .containerImage == $ci and .tags == $tags and .repository == $repo
+              )) | length == 0)
+            ))')
+
+          # If after filtering, no images are left, then we can exit early
+          if jq -e 'length == 0' <<< "$CONTENT_IMAGES" >/dev/null; then
+            echo "All images in the snapshot have already been released in advisories. Stopping pipeline."
+            echo -n "All images have already been released in advisories" > "$(results.result.path)"
+            exit 1
+          fi
+        done
+
+        ORIGINAL_COUNT=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
+        NEW_COUNT=$(echo "$CONTENT_IMAGES" | jq 'length')
+        echo "Filtered out $((ORIGINAL_COUNT - NEW_COUNT)) image(s) already in advisories"
+        echo "Remaining unpublished images: $CONTENT_IMAGES"
+
+        FILTERED_SNAPSHOT=$(jq --argjson images "$CONTENT_IMAGES" '.components = $images' <<< "$SNAPSHOT_JSON")
+
+        echo -n "$FILTERED_SNAPSHOT" > "$(results.filtered_snapshot.path)"
+        echo -n "Success" > "$(results.result.path)"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[0].script = load_str("'"$SCRIPT_DIR"'/mocks.sh") + .spec.steps[0].script' "$TASK_PATH"
+
+kubectl delete secret filter-already-released-advisory-images-secret --ignore-not-found
+kubectl create secret generic filter-already-released-advisory-images-secret --from-literal=git_author_email=tester@tester --from-literal=git_author_name=tester --from-literal=gitlab_access_token=abc --from-literal=gitlab_host=myurl --from-literal=git_repo=https://gitlab.com/org/repo.git

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-already-released-advisory-images.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-images
+spec:
+  description: |
+    Test the filter-already-released-advisory-images-task by providing a snapshot with
+    both released and new images. Expect only the new image after filtering.
+  tasks:
+    - name: run-filter-task
+      taskRef:
+        name: filter-already-released-advisory-images-task
+      params:
+        - name: snapshot_json
+          value: '{"components":[{"name":"released-component","version":"1.0.0","containerImage":"quay.io/test/released-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"},{"name":"new-component","version":"1.0.0","containerImage":"quay.io/test/new-image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
+        - name: origin
+          value: "test-origin"
+        - name: advisory_secret_name
+          value: "filter-already-released-advisory-images-secret"
+        - name: internalRequestPipelineRunName
+          value: "$(context.pipelineRun.name)"
+    - name: validate-result
+      runAfter:
+        - run-filter-task
+      params:
+        - name: filtered_snapshot
+          value: "$(tasks.run-filter-task.results.filtered_snapshot)"
+        - name: result
+          value: "$(tasks.run-filter-task.results.result)"
+      taskSpec:
+        params:
+          - name: filtered_snapshot
+            type: string
+          - name: result
+            type: string
+        steps:
+          - name: validate
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Validating filter task result..."
+
+              if [[ "$(params.result)" != "Success" ]]; then
+                echo "Task result was not Success: $(params.result)"
+                exit 1
+              fi
+
+              COMPONENTS_COUNT=$(jq '.components | length' <<< '$(params.filtered_snapshot)')
+              if [[ "$COMPONENTS_COUNT" -ne 1 ]]; then
+                echo "Expected 1 component after filtering, but found $COMPONENTS_COUNT"
+                exit 1
+              fi
+
+              IMAGE=$(jq -r '.components[0].containerImage' <<< '$(params.filtered_snapshot)')
+              if [[ "$IMAGE" != "quay.io/test/new-image:1.0.0" ]]; then
+                echo "Unexpected remaining image: $IMAGE"
+                exit 1
+              fi
+
+              echo "Validation successful!"

--- a/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
+++ b/tasks/internal/filter-already-released-advisory-images-task/tests/test-filter-no-advisory-directory.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-no-advisory-directory
+spec:
+  description: |
+    Test the task when the advisory directory for the given origin does not exist.
+    Expected behavior: original snapshot is returned unchanged.
+  tasks:
+    - name: run-filter-task
+      taskRef:
+        name: filter-already-released-advisory-images-task
+      params:
+        - name: snapshot_json
+          value: '{"components":[{"name":"test-component","version":"1.0.0","containerImage":"quay.io/test/image:1.0.0","tags":["v1.0"],"repository":"quay.io/test"}]}'
+        - name: origin
+          value: "not-existing-origin"
+        - name: advisory_secret_name
+          value: "filter-already-released-advisory-images-secret"
+        - name: internalRequestPipelineRunName
+          value: "$(context.pipelineRun.name)"
+    - name: validate-result
+      runAfter:
+        - run-filter-task
+      params:
+        - name: filtered_snapshot
+          value: "$(tasks.run-filter-task.results.filtered_snapshot)"
+        - name: result
+          value: "$(tasks.run-filter-task.results.result)"
+      taskSpec:
+        params:
+          - name: filtered_snapshot
+            type: string
+          - name: result
+            type: string
+        steps:
+          - name: validate
+            image: quay.io/konflux-ci/release-service-utils:26e22ecf2c23e7ec8134fede3b40a6e6aef8ac20
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              echo "Validating task result when advisory directory does not exist..."
+              [[ "$(params.result)" == "Success" ]]
+
+              COMPONENTS_COUNT=$(jq '.components | length' <<< '$(params.filtered_snapshot)')
+              if [[ "$COMPONENTS_COUNT" -ne 1 ]]; then
+                echo "Expected 1 component, got $COMPONENTS_COUNT"
+                exit 1
+              fi
+
+              IMAGE=$(jq -r '.components[0].containerImage' <<< '$(params.filtered_snapshot)')
+              if [[ "$IMAGE" != "quay.io/test/image:1.0.0" ]]; then
+                echo "Unexpected image: $IMAGE"
+                exit 1
+              fi
+
+              echo "Validation successful for advisory directory absence!"

--- a/tasks/managed/filter-already-released-advisory-images/README.md
+++ b/tasks/managed/filter-already-released-advisory-images/README.md
@@ -1,0 +1,24 @@
+# Filter Already Released Advisory Images
+
+This task filters out images from a snapshot that have already been published in advisories.  
+It is a **managed Tekton task** that triggers an **internal task** using an InternalRequest, and returns a filtered snapshot JSON containing only **unpublished images**.
+
+## Parameters
+
+| Name                     | Description                                                                                                                | Optional  | Default value                                  |
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------|------------------------------------------------|
+| snapshotPath             | Path to the JSON file of the Snapshot spec in the workspace                                                                | No        | -                                              |
+| releasePlanAdmissionPath | Path to the JSON file of the ReleasePlanAdmission in the workspace                                                         | No        | -                                              |
+| resultsDirPath           | Path to the results directory within the workspace                                                                         | No        | -                                              |
+| request                  | The name of the internal task to be triggered                                                                              | Yes       | filter-already-released-advisory-images        |
+| synchronously            | Whether the task should wait for the InternalRequest to complete                                                           | Yes       | true                                           |
+| pipelineRunUid           | UID of the current pipelineRun, used as a label on the InternalRequest                                                     | No        | -                                              |
+| taskGitUrl               | Git URL of the release-service-catalog containing internal task logic                                                      | No        | -                                              |
+| taskGitRevision          | Git revision or branch name used to run the internal task                                                                  | No        | -                                              |
+| ociStorage               | The OCI repository where the Trusted Artifacts are stored                                                                  | No        | -                                              |
+| ociArtifactExpiresAfter  | Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire | Yes       | 1d                                             |
+| trustedArtifactsDebug    | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                                     | Yes       | ""                                             |
+| orasOptions              | oras options to pass to Trusted Artifacts calls                                                                            | Yes       | ""                                             |
+| sourceDataArtifact       | Location of trusted artifacts used to populate the data directory                                                          | Yes       | ""                                             |
+| dataDir                  | The location where data will be stored                                                                                     | No        | $(workspaces.data.path)                        |
+| subdirectory             | Subdirectory inside the workspace to be used                                                                               | Yes       | ""                                             |

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -1,0 +1,284 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: filter-already-released-advisory-images
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: |
+    Managed Tekton task that filters out already-released images from a snapshot
+    via an InternalRequest.
+  params:
+    - name: snapshotPath
+      type: string
+      description: Path to the JSON string of the Snapshot spec in the data workspace
+    - name: releasePlanAdmissionPath
+      type: string
+      description: Path to the JSON string of the ReleasePlanAdmission in the data workspace
+    - name: resultsDirPath
+      type: string
+      description: Path to the results directory in the data workspace
+    - name: request
+      type: string
+      description: Type of request to be created
+      default: "filter-already-released-advisory-images"
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+      default: "empty"
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: sourceDataArtifact
+      type: string
+      description: Location of trusted artifacts to be used to populate data directory
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+      default: $(workspaces.data.path)
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: Git revision to use for internal task
+    - name: pipelineRunUid
+      type: string
+      description: UID of the current pipelineRun
+    - name: synchronously
+      type: string
+      description: Whether to wait for the InternalRequest completion
+      default: "true"
+    - name: subdirectory
+      description: Subdirectory inside the workspace to be used
+      type: string
+      default: ""
+  workspaces:
+    - name: data
+      description: Workspace to mount internal request outputs
+  results:
+    - name: result
+      description: Success or failure result
+    - name: filtered_snapshot
+      description: Snapshot JSON with only unpublished images
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
+      type: string
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+  steps:
+    - name: skip-trusted-artifact-operations
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/skip-trusted-artifact-operations/skip-trusted-artifact-operations.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+    - name: use-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: run-script
+      image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+      script: |
+        #!/bin/bash
+        set -eux
+
+        SNAPSHOT_FILE="$(params.dataDir)/$(params.snapshotPath)"
+        if [ ! -f "$SNAPSHOT_FILE" ]; then
+            echo "No valid snapshot file was provided at $SNAPSHOT_FILE"
+            exit 1
+        fi
+        snapshot=$(jq -c '.' "$SNAPSHOT_FILE")
+        if [ -z "$snapshot" ]; then
+            echo "Failed to read snapshot file"
+            exit 1
+        fi
+
+        RPA_FILE="$(params.dataDir)/$(params.releasePlanAdmissionPath)"
+        if [ ! -f "$RPA_FILE" ]; then
+            echo "No valid ReleasePlanAdmission file was provided at $RPA_FILE"
+            exit 1
+        fi
+        origin=$(jq -r '.spec.origin' "$RPA_FILE")
+        if [ -z "$origin" ]; then
+            echo "Failed to read origin from ReleasePlanAdmission"
+            exit 1
+        fi
+
+        pipelinerun_label="internal-services.appstudio.openshift.io/pipelinerun-uid"
+
+        # Determine advisory_secret_name based on repositories in snapshot
+        pending_repositories=$(jq -r '.components[] | select(.repository |
+          contains("quay.io/redhat-pending/")) |
+          .repository' "$SNAPSHOT_FILE")
+        prod_repositories=$(jq -r '.components[] | select(.repository | contains("quay.io/redhat-prod/")) |
+          .repository' "$SNAPSHOT_FILE")
+        orphan_repositories=$(jq -r '.components[] | select(.repository | contains("quay.io/redhat-prod/") |
+          not) | select(.repository | contains("quay.io/redhat-pending/") | not) |
+          .repository' "$SNAPSHOT_FILE")
+        foundPendingRepositories=false
+        [ -n "${pending_repositories}" ] && foundPendingRepositories=true
+        foundProdRepositories=false
+        [ -n "${prod_repositories}" ] && foundProdRepositories=true
+        foundOrphanRepositories=false
+        [ -n "${orphan_repositories}" ] && foundOrphanRepositories=true
+
+        echo "Repository status:"
+        echo "- Pending repositories: ${foundPendingRepositories}"
+        echo "- Production repositories: ${foundProdRepositories}"
+        echo "- Orphan repositories: ${foundOrphanRepositories}"
+
+        if [ "${foundPendingRepositories}" == "true" ] && [ "${foundProdRepositories}" == "true" ]; then
+          echo "Error: cannot publish to both redhat-pending and redhat-prod repositories"
+          exit 1
+        fi
+
+        if [ "${foundPendingRepositories}" == "false" ] && [ "${foundProdRepositories}" == "false" ]; then
+          echo "Error: you must publish to either redhat-pending or redhat-prod repositories"
+          exit 1
+        fi
+
+        if [ "${foundOrphanRepositories}" == "true" ]; then
+          echo "Error: you must publish to either redhat-pending or redhat-prod repositories"
+          exit 1
+        fi
+
+        # Select the correct secret name
+        advisorySecretName="create-advisory-prod-secret"
+        if [ "${foundPendingRepositories}" == "true" ]; then
+          advisorySecretName="create-advisory-stage-secret"
+        fi
+
+        RESULTS_FILE="$(params.dataDir)/$(params.resultsDirPath)/filter-already-released-advisory-images-results.json"
+        IR_FILE="$(params.dataDir)/$(context.task.name)/ir-result.txt"
+        mkdir -p "$(dirname "$IR_FILE")"
+
+        echo "Creating internal request for filtering already-released advisory images..."
+        internal-request --pipeline "$(params.request)" \
+                         -p snapshot_json="$snapshot" \
+                         -p origin="$origin" \
+                         -p advisory_secret_name="$advisorySecretName" \
+                         -p internalRequestPipelineRunName="$(params.pipelineRunUid)" \
+                         -p taskGitUrl="$(params.taskGitUrl)" \
+                         -p taskGitRevision="$(params.taskGitRevision)" \
+                         -s "$(params.synchronously)" \
+                         -l ${pipelinerun_label}="$(params.pipelineRunUid)" \
+                         > "$IR_FILE" || (grep "^\[" "$IR_FILE" | jq . && exit 1)
+
+        internalRequest=$(awk -F"'" '/created/ { print $2 }' "$IR_FILE")
+        echo "Internal request created: ${internalRequest}"
+
+        echo "Internal request status:"
+        kubectl get internalrequest "${internalRequest}" -o json | jq .
+
+        results=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results}')
+        if [ -z "$results" ]; then
+          echo "No results found in internal request. Status:"
+          kubectl get internalrequest "${internalRequest}" -o yaml
+          exit 1
+        fi
+
+        internalRequestPipelineRunName="$(jq -jr '.internalRequestPipelineRunName // ""' <<< "${results}")"
+        internalRequestTaskRunName="$(jq -jr '.internalRequestTaskRunName // ""' <<< "${results}")"
+        echo "Internal request details:"
+        echo "- Pipeline run: ${internalRequestPipelineRunName}"
+        echo "- Task run: ${internalRequestTaskRunName}"
+
+        if [[ "$(echo "$results" | jq -r '.result')" == "Success" ]]; then
+          echo "Image filtering successful"
+          FILTERED_SNAPSHOT=$(echo "$results" | jq -r '.filtered_snapshot // ""')
+          if [ -z "$FILTERED_SNAPSHOT" ]; then
+            echo "No filtered snapshot found in results. Results:"
+            echo "$results"
+            exit 1
+          fi
+
+          FILTERED_SNAPSHOT_PATH="$(params.subdirectory)/filtered_snapshot.json"
+          echo "$FILTERED_SNAPSHOT" > "$(params.dataDir)/$FILTERED_SNAPSHOT_PATH"
+          echo -n "$FILTERED_SNAPSHOT_PATH" > "$(results.filtered_snapshot.path)"
+          echo -n "Success" > "$(results.result.path)"
+          jq -n --arg snapshot "$FILTERED_SNAPSHOT" '{"filtered_snapshot": $snapshot}' | tee "$RESULTS_FILE"
+        else
+          echo "Filtering failed. Results:"
+          echo "$results"
+          exit 1
+        fi
+    - name: create-trusted-artifact
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)
+    - name: patch-source-data-artifact-result
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/patch-source-data-artifact-result/patch-source-data-artifact-result.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ex
+
+# mocks to be injected into task step scripts
+
+function kubectl() {
+  # The IR won't actually be acted upon, so mock it to return Success as the task wants
+  if [[ "$*" == "get internalrequest "*"-o=jsonpath={.status.results}" ]]
+  then
+    echo '{
+      "result": "Success",
+      "filtered_snapshot": "{\"application\":\"myapp\",\"components\":[{\"name\":\"new-component\",\"repository\":\"quay.io/redhat-pending/repo2\",\"containerImage\":\"quay.io/redhat-pending/repo2@sha256:def456\"}]}",
+      "internalRequestPipelineRunName": "test-pipeline-run",
+      "internalRequestTaskRunName": "test-task-run"
+    }'
+  else
+    /usr/bin/kubectl "$@"
+  fi
+}

--- a/tasks/managed/filter-already-released-advisory-images/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/pre-apply-task-hook.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Install the CRDs so we can create/get them
+.github/scripts/install_crds.sh
+
+# Add RBAC so that the SA executing the tests can retrieve CRs
+kubectl apply -f .github/resources/crd_rbac.yaml
+
+# delete old InternalRequests
+kubectl delete internalrequests --all -A
+
+TASK_PATH="$1"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Add mocks to the beginning of task step script
+yq -i '.spec.steps[2].script = load_str("'$SCRIPT_DIR'/mocks.sh") + .spec.steps[2].script' "$TASK_PATH"

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images.yaml
@@ -1,0 +1,301 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-images
+spec:
+  description: |
+    Run the filter-already-released-advisory-images managed task and validate it creates an InternalRequest correctly.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "released-component",
+                    "repository": "quay.io/redhat-pending/repo",
+                    "containerImage": "quay.io/redhat-pending/repo@sha256:abc123"
+                  },
+                  {
+                    "name": "new-component",
+                    "repository": "quay.io/redhat-pending/repo2",
+                    "containerImage": "quay.io/redhat-pending/repo2@sha256:def456"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: check-result
+      runAfter:
+        - run-task
+      taskSpec:
+        workspaces:
+          - name: data
+        params:
+          - name: filtered_snapshot
+            type: string
+          - name: result
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # Count the number of InternalRequests
+              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+              
+              # Check if the number of InternalRequests is as expected
+              if [ "$requestsCount" -ne 1 ]; then
+                echo "Unexpected number of InternalRequests. Expected: 1, Found: $requestsCount"
+                exit 1
+              fi
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check if the 'pipelineRef' field contains the correct pipeline path
+              expected_pipeline="pipelines/internal/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml"
+              pipeline_ref=$(echo "$internalRequest" | jq -r '.spec.pipeline.pipelineRef.params[2].value')
+              if [[ "$pipeline_ref" != "$expected_pipeline" ]]; then
+                echo "InternalRequest doesn't contain the correct pipeline path"
+                exit 1
+              fi
+
+              # Check the snapshot_json parameter
+              snapshotJson=$(echo "$internalRequest" | jq -r '.spec.params.snapshot_json')
+              if [ "$(jq -r '.application' <<< "$snapshotJson")" != "myapp" ]; then
+                echo "InternalRequest has the wrong application in snapshot_json"
+                exit 1
+              fi
+
+              # Check the origin parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.origin' )" != "dev" ]; then
+                echo "InternalRequest has the wrong origin parameter"
+                exit 1
+              fi
+
+              # Check the advisory_secret_name parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.advisory_secret_name' )" != \
+                "create-advisory-stage-secret" ]; then
+                echo "InternalRequest has the wrong advisory_secret_name parameter"
+                exit 1
+              fi
+
+              # Check the taskGitUrl parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitUrl' )" != "http://localhost" ]; then
+                echo "InternalRequest has the wrong taskGitUrl parameter"
+                exit 1
+              fi
+
+              # Check the taskGitRevision parameter
+              if [ "$(echo "$internalRequest" | jq -r '.spec.params.taskGitRevision' )" != "main" ]; then
+                echo "InternalRequest has the wrong taskGitRevision parameter"
+                exit 1
+              fi
+
+              # Check that the filtered snapshot contains only the new component
+              base_dir="$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              results_file="$base_dir/filter-already-released-advisory-images-results.json"
+              filteredSnapshot=$(jq -r '.filtered_snapshot' "$results_file")
+              if [ "$(jq -r '.components | length' <<< "$filteredSnapshot")" != "1" ]; then
+                echo "Filtered snapshot should contain only one component"
+                exit 1
+              fi
+              if [ "$(jq -r '.components[0].name' <<< "$filteredSnapshot")" != "new-component" ]; then
+                echo "Filtered snapshot should contain only the new component"
+                exit 1
+              fi
+
+              # Check that the result was properly set
+              if [ "$(params.result)" != "Success" ]; then
+                echo "Task failed: $(params.result)"
+                exit 1
+              fi
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+      params:
+        - name: filtered_snapshot
+          value: $(tasks.run-task.results.filtered_snapshot)
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: "$(params.dataDir)"
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-prod-or-pending.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-no-prod-or-pending
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with a snapshot containing only non-prod and non-pending
+    repositories and verify the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "dev-component",
+                    "repository": "quay.io/redhat-dev/repo",
+                    "containerImage": "quay.io/redhat-dev/repo@sha256:abc123"
+                  },
+                  {
+                    "name": "other-component",
+                    "repository": "quay.io/other/repo",
+                    "containerImage": "quay.io/other/repo@sha256:def456"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-rpa.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-no-rpa
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with no ReleasePlanAdmission and verify it fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      type: string
+      description: The OCI repository where the Trusted Artifacts are stored.
+    - name: ociArtifactExpiresAfter
+      type: string
+      default: "1d"
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
+      description: The location where data will be stored.
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-missing-rpa-inputs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "repository": "quay.io/redhat-prod/repo",
+                    "tags": ["v1.0"],
+                    "containerImage": "quay.io/redhat-prod/repo@sha256:abc123"
+                  }
+                ]
+              }
+              EOF
+              # Note: No RPA file created
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      runAfter:
+        - setup
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/missing_rpa.json"  # this file doesn't exist
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-no-snapshot.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-no-snapshot
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with no Snapshot and verify it fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      type: string
+      description: The OCI repository where the Trusted Artifacts are stored.
+    - name: ociArtifactExpiresAfter
+      type: string
+      default: "1d"
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
+      description: The location where data will be stored.
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-missing-snapshot-inputs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "spec": {
+                  "origin": "dev"
+                }
+              }
+              EOF
+              # Note: No snapshot file created
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      runAfter:
+        - setup
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/missing_snapshot.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      workspaces:
+        - name: data
+          workspace: tests-workspace

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-orphan.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-orphan
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with a snapshot containing both prod and non-prod
+    repositories (orphan scenario) and verify the task fails as expected.
+  workspaces:
+    - name: tests-workspace
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        workspaces:
+          - name: data
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+            - name: DEBUG
+              value: $(params.trustedArtifactsDebug)
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils:0f82be4be43294b6a96846d87ef7f7c0b9e34267
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "prod-component",
+                    "repository": "quay.io/redhat-prod/repo",
+                    "containerImage": "quay.io/redhat-prod/repo@sha256:abc123"
+                  },
+                  {
+                    "name": "dev-component",
+                    "repository": "quay.io/redhat-dev/repo",
+                    "containerImage": "quay.io/redhat-dev/repo@sha256:def456"
+                  }
+                ]
+              }
+              EOF
+          - name: skip-trusted-artifact-operations
+            ref:
+              name: skip-trusted-artifact-operations
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+          - name: patch-source-data-artifact-result
+            ref:
+              name: patch-source-data-artifact-result
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+      workspaces:
+        - name: data
+          workspace: tests-workspace
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+      runAfter:
+        - setup
+      workspaces:
+        - name: data
+          workspace: tests-workspace


### PR DESCRIPTION
Add filter-already-released-advisory-images task
to make rh-advisories pipeline idempotent

- Creates new task to filter out images already published in advisories
- Places task after apply-mapping and before EC validation
- Updates all subsequent tasks to use filtered snapshot
- Includes tests and documentation